### PR TITLE
Fix error when calling JuMP.shadow_price

### DIFF
--- a/src/types/decision_constraint.jl
+++ b/src/types/decision_constraint.jl
@@ -732,7 +732,7 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}) where {
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return JuMP.shadow_price_less_than_(dual(sp_cref), objective_sense(sp))
+    return JuMP._shadow_price_less_than(dual(sp_cref), objective_sense(sp))
 end
 """
     shadow_price(sp_cref::SPConstraintRef, scenario_index::Integer)
@@ -748,7 +748,7 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}, scenari
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return JuMP.shadow_price_less_than_(dual(sp_cref, scenario_index), objective_sense(sp, scenario_index))
+    return JuMP._shadow_price_less_than(dual(sp_cref, scenario_index), objective_sense(sp, scenario_index))
 end
 
 function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}) where {F, S <: MOI.GreaterThan}
@@ -758,7 +758,7 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}) where {
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return JuMP.shadow_price_greater_than_(dual(sp_cref), objective_sense(sp))
+    return JuMP._shadow_price_greater_than(dual(sp_cref), objective_sense(sp))
 end
 function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}, scenario_index::Integer) where {F, S <: MOI.GreaterThan}
     stage(sp_cref) == 1 && error("$sp_cref is not scenario dependent, consider `shadow_price(sp_cref)`.")
@@ -767,7 +767,7 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}, scenari
         error("The shadow price is not available because no dual result is " *
               "available.")
     end
-    return JuMP.shadow_price_greater_than_(dual(sp_cref, scenario_index), objective_sense(sp, scenario_index))
+    return JuMP._shadow_price_greater_than(dual(sp_cref, scenario_index), objective_sense(sp, scenario_index))
 end
 
 function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}) where {F, S <: MOI.EqualTo}
@@ -780,9 +780,9 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}) where {
     sense = objective_sense(sp)
     dual_val = dual(sp_cref)
     if dual_val > 0
-        return JuMP.shadow_price_greater_than_(dual_val, sense)
+        return JuMP._shadow_price_greater_than(dual_val, sense)
     else
-        return JuMP.shadow_price_less_than_(dual_val, sense)
+        return JuMP._shadow_price_less_than(dual_val, sense)
     end
 end
 function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}, scenario_index::Integer) where {F, S <: MOI.EqualTo}
@@ -795,9 +795,9 @@ function JuMP.shadow_price(sp_cref::SPConstraintRef{JuMP._MOICON{F, S}}, scenari
     sense = objective_sense(sp, scenario_index)
     dual_val = dual(sp_cref, scenario_index)
     if dual_val > 0
-        return JuMP.shadow_price_greater_than_(dual_val, sense)
+        return JuMP._shadow_price_greater_than(dual_val, sense)
     else
-        return JuMP.shadow_price_less_than_(dual_val, sense)
+        return JuMP._shadow_price_less_than(dual_val, sense)
     end
 end
 """

--- a/test/decisions/solve.jl
+++ b/test/decisions/solve.jl
@@ -195,6 +195,7 @@ function test_solve(Structure, mockoptimizer, master_optimizer, subproblem_optim
     @test  2.0 == @inferred JuMP.reduced_cost(x)
     @test  0.0 == @inferred JuMP.reduced_cost(y, 1)
     @test -1.0 == @inferred JuMP.dual(c, 1)
+    @test -1.0 == @inferred JuMP.shadow_price(c, 1)
     @test  2.0 == @inferred JuMP.dual(JuMP.LowerBoundRef(x))
     @test  0.0 == @inferred JuMP.dual(JuMP.LowerBoundRef(y), 1)
 end


### PR DESCRIPTION
Hi @martinbiel, thank you for writing such a nice package.

Currently StochasticPrograms.jl fails when the user calls `JuMP.shadow_price(constr, scenario_index)` with the error below:
```
test_solve: Error During Test at /home/axavier/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:198
  Test threw exception
  Expression: -1.0 == #= /home/axavier/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:198 =# @inferred(JuMP.shadow_price(c, 1))
  UndefVarError: shadow_price_less_than_ not defined
  Stacktrace:
   [1] shadow_price(sp_cref::SPConstraintRef{MathOptInterface.ConstraintIndex{AffineDecisionFunction{Float64}, MathOptInterface.LessThan{Float64}}, ScalarShape}, scenario_index::Int64)
     @ StochasticPrograms ~/Packages/StochasticPrograms.jl/pr/src/types/decision_constraint.jl:751
   [2] test_solve(Structure::Deterministic, mockoptimizer::MathOptInterface.Utilities.MockOptimizer{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, master_optimizer::MathOptInterface.Utilities.MockOptimizer{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}}, subproblem_optimizer::MathOptInterface.Utilities.MockOptimizer{MathOptInterface.Utilities.GenericModel{Float64, MathOptInterface.Utilities.ModelFunctionConstraints{Float64}}})
     @ Main.TestSolve ~/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:198
   [3] macro expansion
     @ ~/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:215 [inlined]
   [4] macro expansion
     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [5] macro expansion
     @ ~/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:215 [inlined]
   [6] macro expansion
     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [7] macro expansion
     @ ~/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:209 [inlined]
   [8] macro expansion
     @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [9] runtests()
     @ Main.TestSolve ~/Packages/StochasticPrograms.jl/pr/test/decisions/solve.jl:205
```
The issue is that some internal JuMP functions have been renamed in [d9f5835b](https://github.com/jump-dev/JuMP.jl/commit/d9f5835be19b7b8025be2c1a980d16662fc4441c). This PR adds a failing test for the problem and fixes it.